### PR TITLE
Ensure determinism of calculation when using full-batch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonparametricVI"
 uuid = "2fb14f58-0ee9-4f79-83b0-fac5a8c3c025"
 authors = ["Amirabbas Asadi"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/discrepancies.jl
+++ b/src/discrepancies.jl
@@ -54,7 +54,11 @@ function kernelized_stein_discrepancy(
     # sampling a set of particles for evaluating KSD
     n = size(P)[2]
     samplesize = min(n, samplesize)
-    S = StatsBase.sample(1:n, samplesize; replace=false)
+    if samplesize == n
+        S = collect(1:n)
+    else
+        S = StatsBase.sample(1:n, samplesize; replace=false)
+    end
 
     D = 0
     for i in 1:samplesize

--- a/src/stein/svgd.jl
+++ b/src/stein/svgd.jl
@@ -103,7 +103,11 @@ function particle_velocity(pc::ParticleContainer,
     end
     
     # sample a mini-batch
-    S = StatsBase.sample(1:pc.size, batchsize; replace=false)
+    if batchsize == pc.size
+        S = collect(1:pc.size)
+    else
+        S = StatsBase.sample(1:pc.size, batchsize; replace=false)
+    end
     # compute velocity
     minibtach_∇ = [zeros(pc.dim) for i in 1:batchsize]
 

--- a/test/test_discrepancy.jl
+++ b/test/test_discrepancy.jl
@@ -28,4 +28,10 @@
     @test D_stein_P2 < D_stein_P1
     @test D_stein_P2 < D_stein_P3
 
+    @testset "Full-batch determinism" begin
+        D1 = NonparametricVI.kernelized_stein_discrepancy(P1, ∇ρ, kernel; samplesize=size(P1, 2), ad_backend=AutoForwardDiff())
+        D2 = NonparametricVI.kernelized_stein_discrepancy(P1, ∇ρ, kernel; samplesize=size(P1, 2), ad_backend=AutoForwardDiff())
+        @test D1 == D2
+    end
+        
 end


### PR DESCRIPTION
Hi! Thanks for this nice Julia package. I was playing around with it and noticed that the metric and velocity calculations are not deterministic even when using full-batch, due to the order of floating point operations changing in each call. This PR fixes that.